### PR TITLE
added process complete hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ results
 npm-debug.log
 node_modules
 coverage
+.idea/

--- a/lib/gulp-istanbul-enforcer.js
+++ b/lib/gulp-istanbul-enforcer.js
@@ -43,6 +43,7 @@ var GulpIstanbulEnforcerFactory = function(){
 					var pluginError = new PluginError('gulp-istanbul-enforcer', error);
 					self.emit('error', pluginError);
 				}
+                self.emit('end');
 				done();
 			});
 		});

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "author": "Iain Mitchell <iainjmitchell@gmail.com>",
   "description": "Plugin for gulp that enforces coverage thresholds from Istanbul",
   "license": "MIT",
+  "contributors": [
+    "Daniel Lamb <dlamb.open.source@gmail.com>"
+  ],
   "bugs": {
     "url": "https://github.com/iainjmitchell/gulp-istanbul-enforcer/issues"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "dependencies" : {
     "istanbul" : "*",
     "through2" : "*",

--- a/test/enforce-coverage-tests.js
+++ b/test/enforce-coverage-tests.js
@@ -111,6 +111,21 @@ describe('When coverage is enforced', function(){
 		mockCommand.runArguments.should.include('--root=' + rootDirectory);
 	});
 
+    it('Then it should signal the process is complete', function (done) {
+        var coverageMetThresholdsCommand = {
+            run : function(runArguments, callback){
+                callback(null);
+            }
+        };
+        CoverageEnforcer.__set__('commandFactory', new FakeCommandFactory(coverageMetThresholdsCommand));
+        var stream = CoverageEnforcer({thresholds : {}});
+        stream.on('end', function(){
+            done();
+        });
+        stream.write();
+        stream.end();
+    });
+
 	it('Then it should call the callback for the flush method', function (done) {
 		var fakeCommand = {
 				run : function(runArguments, callback){


### PR DESCRIPTION
**Use case:** I want to show a message when there are errors and when there are not.

``` javascript
  var noErrors = true;
  gulp.src('.')
      .pipe(enforcer({ … }))
      .on('error', function(e) {
        noErrors = false;
        // log errors to the console
      })
      .on('end', function(e) {
        if (noErrors) {
          // log coverage levels ok to the console
        }
      });
```
